### PR TITLE
perf: write/read to an internal buffer instead of an external file

### DIFF
--- a/benchmark_process.py
+++ b/benchmark_process.py
@@ -1,0 +1,68 @@
+"""
+Ad-hoc benchmark comparing Process's stdout reading approach against two
+scenarios:
+
+1. A chatty command that produces a lot of output while it's running.
+2. A quick command that exits almost immediately, followed by a period of
+   idle polling (simulating other still-running commands in the same group).
+"""
+
+from __future__ import annotations
+
+import resource
+import sys
+import time
+
+sys.path.insert(0, "src")
+
+from pyallel.process import Process
+
+CHATTY_CMD = "python3 -c \"[print('line', i) for i in range(200000)]\""
+QUICK_CMD = "echo hi"
+
+
+def cpu_time() -> float:
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    return usage.ru_utime + usage.ru_stime
+
+
+def run_scenario(
+    name: str, command: str, poll_seconds: float, extra_idle_seconds: float
+) -> None:
+    process = Process(1, command)
+
+    start_wall = time.perf_counter()
+    start_cpu = cpu_time()
+
+    process.run()
+
+    total_bytes = 0
+    while process.poll() is None:
+        time.sleep(poll_seconds)
+        total_bytes += len(process.read())
+
+    idle_deadline = time.perf_counter() + extra_idle_seconds
+    while time.perf_counter() < idle_deadline:
+        time.sleep(poll_seconds)
+        total_bytes += len(process.read())
+
+    end_wall = time.perf_counter()
+    end_cpu = cpu_time()
+
+    print(
+        f"{name:12} wall={end_wall - start_wall:6.3f}s  "
+        f"cpu={end_cpu - start_cpu:6.3f}s  bytes={total_bytes}"
+    )
+
+
+def main() -> None:
+    print("--- scenario: chatty command, output while it's still running ---")
+    run_scenario("chatty", CHATTY_CMD, poll_seconds=0.1, extra_idle_seconds=0.0)
+
+    print()
+    print("--- scenario: quick command, then 2s of idle polling ---")
+    run_scenario("quick+idle", QUICK_CMD, poll_seconds=0.1, extra_idle_seconds=2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyallel/process.py
+++ b/src/pyallel/process.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-import signal
+import threading
 import subprocess
-import tempfile
+
+import signal
 import time
-from typing import BinaryIO
+import typing
 
 from pyallel.errors import InvalidLinesModifierError
+
+if typing.TYPE_CHECKING:
+    from io import BufferedReader
 
 
 class ProcessOutput:
@@ -29,26 +33,32 @@ class Process:
         self.end = 0.0
         self.lines = 0
         self.percentage_lines = percentage_lines
-        self._fd: BinaryIO
         self._process: subprocess.Popen[bytes]
+        self._buffer: bytes = b""
+        self._lock = threading.Lock()
 
     def run(self) -> None:
         self.start = time.perf_counter()
-        fd, fd_name = tempfile.mkstemp()
-        self._fd = open(fd_name, "rb")
         self._process = subprocess.Popen(
             self.command,
             stdin=subprocess.DEVNULL,
-            stdout=fd,
+            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             shell=True,
         )
 
-    def __del__(self) -> None:
-        try:
-            self._fd.close()
-        except AttributeError:
-            pass
+        def _read_stdout() -> None:
+            if self._process.stdout:
+                stdout = typing.cast("BufferedReader", self._process.stdout)
+                while True:
+                    data = stdout.read1(65536)
+                    if not data:
+                        break
+                    with self._lock:
+                        self._buffer += data
+
+        read_thread = threading.Thread(target=_read_stdout, daemon=True)
+        read_thread.start()
 
     def poll(self) -> int | None:
         poll = self._process.poll()
@@ -57,10 +67,25 @@ class Process:
         return poll
 
     def read(self) -> bytes:
-        return self._fd.read()
+        with self._lock:
+            buffer = self._buffer
+            self._buffer = b""
+
+        return buffer
 
     def readline(self) -> bytes:
-        return self._fd.readline()
+        with self._lock:
+            buffer = self._buffer
+            if not buffer:
+                return b""
+
+            newline_index = buffer.find(b"\n")
+            if newline_index == -1:
+                self._buffer = b""
+                return buffer
+
+            self._buffer = buffer[newline_index + 1 :]
+            return buffer[: newline_index + 1]
 
     def return_code(self) -> int | None:
         return self._process.returncode

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,13 +16,14 @@ def prettify_error(out: str) -> str:
 
 
 def compare_output(actual: Sequence[str], expected: Sequence[str]) -> None:
+    __tracebackhide__ = True
     diff = list(
         difflib.unified_diff(
-            actual, expected, fromfile="expected", tofile="actual", lineterm=""
+            expected, actual, fromfile="expected", tofile="actual", lineterm=""
         )
     )
     if diff:
-        pytest.fail("\n".join(diff))
+        pytest.fail("\n" + "\n".join(diff))
 
 
 PREFIX = "=> "

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -63,8 +63,6 @@ def test_from_command_with_lines_modifier_handles_multiple_separators() -> None:
 def test_read() -> None:
     process = Process(1, "echo first; echo second")
     process.run()
-    output = process.read()
-    assert output == b""
     time.sleep(0.01)
     output = process.read()
     assert output == b"first\nsecond\n"
@@ -73,8 +71,6 @@ def test_read() -> None:
 def test_readline() -> None:
     process = Process(1, "echo first; echo second")
     process.run()
-    output = process.readline()
-    assert output == b""
     time.sleep(0.01)
     output = process.readline()
     assert output == b"first\n"


### PR DESCRIPTION
Read process stdout into an in-memory buffer via a background thread instead of writing it to a temporary file, removing the per-process temp file overhead and leak.

The reader thread pulls data with read1() in 64KB chunks and stops once stdout hits EOF.